### PR TITLE
Fix for template constructor syntax in header file

### DIFF
--- a/src/framework/JetScapeWriterStream.h
+++ b/src/framework/JetScapeWriterStream.h
@@ -34,9 +34,9 @@ namespace Jetscape {
 template <class T> class JetScapeWriterStream : public JetScapeWriter {
 
 public:
-  JetScapeWriterStream<T>(){};
-  JetScapeWriterStream<T>(string m_file_name_out);
-  virtual ~JetScapeWriterStream<T>();
+  JetScapeWriterStream(){};
+  JetScapeWriterStream(string m_file_name_out);
+  virtual ~JetScapeWriterStream();
 
   void Init();
   void Exec();


### PR DESCRIPTION
Without this fix compiling issues might appear with default recipes while building AliGenerators.
(Tested on Ubuntu) 
When/if approved a new tag is requested (v3.1.1alice-6) to be updated in the alidist recipe as well
(another PR will follow).